### PR TITLE
Fix bugs in signal processing functions

### DIFF
--- a/patrons/src/main/cpp/patrons_core.c
+++ b/patrons/src/main/cpp/patrons_core.c
@@ -250,7 +250,7 @@ Java_com_alibaba_android_patronus__1Patrons__1_1init(__unused JNIEnv *env, __unu
         LOGE("signal handler reg failed.");
     } else {
         has_exception_handle_ = true;
-        LOGI("signal handler reg success, old handler = %p", &sig_act_old[SIGSEGV]);
+        LOGI("signal handler reg success, old handler = %p", &sig_act_old);
     }
 
     int initCode;
@@ -325,11 +325,12 @@ Java_com_alibaba_android_patronus__1Patrons_shrinkRegionSpace(__unused JNIEnv *e
         return false;
     }
 
+    bool ret = false;
     if (ClampGrowthLimit && region_space_) {
         if (has_exception_handle_ && !debuggable) {
             i_want_handle_signal_flag = 1;
             if (0 == sigsetjmp(time_machine, 1)) {
-                ResizeRegionSpace(new_size * MB);
+                ret = ResizeRegionSpace(new_size * MB);
             } else {
                 LOGE("resize failed, found exception signal.");
                 return false;
@@ -337,7 +338,7 @@ Java_com_alibaba_android_patronus__1Patrons_shrinkRegionSpace(__unused JNIEnv *e
 
             i_want_handle_signal_flag = 0;
         } else {
-            return ResizeRegionSpace(new_size * MB);
+            ret = ResizeRegionSpace(new_size * MB);
         }
     } else {
         LOGE("resize failed, key param is NULL, instance = %p, method = %p.",
@@ -347,7 +348,7 @@ Java_com_alibaba_android_patronus__1Patrons_shrinkRegionSpace(__unused JNIEnv *e
         return false;
     }
 
-    return true;
+    return ret;
 }
 
 JNIEXPORT jlong JNICALL

--- a/patrons/src/main/cpp/xhook/xh_core.c
+++ b/patrons/src/main/cpp/xhook/xh_core.c
@@ -89,23 +89,37 @@ static int              xh_core_sigsegv_enable = 1; //enable by default
 static struct sigaction xh_core_sigsegv_act_old;
 static volatile int     xh_core_sigsegv_flag = 0;
 static sigjmp_buf       xh_core_sigsegv_env;
-static void xh_core_sigsegv_handler(int sig)
+static void xh_core_sigsegv_handler(int signum, siginfo_t* siginfo, void* context)
 {
-    (void)sig;
-    
     if(xh_core_sigsegv_flag)
         siglongjmp(xh_core_sigsegv_env, 1);
     else
-        sigaction(SIGSEGV, &xh_core_sigsegv_act_old, NULL);
+    {
+        // sigaction(SIGSEGV, &xh_core_sigsegv_act_old, NULL);
+        if (xh_core_sigsegv_act_old.sa_flags & SA_SIGINFO) {
+            xh_core_sigsegv_act_old.sa_sigaction(signum, siginfo, context);
+        } else {
+            if (SIG_DFL == xh_core_sigsegv_act_old.sa_handler) {
+                // If the previous handler was the default handler, cause a core dump.
+                signal(signum, SIG_DFL);
+                raise(signum);
+            } else if (SIG_IGN == xh_core_sigsegv_act_old.sa_handler) {
+                return;
+            } else {
+                xh_core_sigsegv_act_old.sa_handler(signum);
+            }
+        }
+    }
 }
 static int xh_core_add_sigsegv_handler()
 {
-    struct sigaction act;
+    struct sigaction act = {0};
 
     if(!xh_core_sigsegv_enable) return 0;
     
     if(0 != sigemptyset(&act.sa_mask)) return (0 == errno ? XH_ERRNO_UNKNOWN : errno);
-    act.sa_handler = xh_core_sigsegv_handler;
+    act.sa_flags = SA_SIGINFO | SA_ONSTACK | SA_RESTART;
+    act.sa_sigaction = xh_core_sigsegv_handler;
     
     if(0 != sigaction(SIGSEGV, &act, &xh_core_sigsegv_act_old))
         return (0 == errno ? XH_ERRNO_UNKNOWN : errno);


### PR DESCRIPTION
Patrons在信号处理这块有点问题：
xhook和Patrons都针对SIGSEGV做了特殊处理，用来防止自己的core dump扩散到外面。外面的信号被xhook或者Patrons捕获到时会调用sigaction把old信号处理函数重新注册成新的信号处理函数（等同放弃了自己的信号保护机制），

按代码信号处理函数注册时机来说，如果Patrons代码块的信号处理函数捕获到xhook代码块的SIGSEGV，Patrons代码块判断不是自己内部的便放弃了自己的信号处理函数并把xhook的信号处理函数注册成新的信号处理函数，最终会触发了xhook的信号处理函数，程序不会崩溃，程序执行一段时间后，如果Patrons代码块发出了SIGSEGV信号，SIGSEGV信号会被xhook的信号处理函数处理，程序就崩溃了。并没有做到杜绝因为Patrons崩溃而造成APP崩溃。

参考Android处理方案，直接调用旧的信号处理函数即可。
https://cs.android.com/android/platform/superproject/+/master:external/gwp_asan/gwp_asan/optional/segv_handler_posix.cpp
![image](https://github.com/alibaba/Patrons/assets/44021277/66c9dcdf-e72d-4ed1-9882-bc4580b90b0c)

回归机型：
Android 12
ONEPLUS LE2110
SAMSUNG  SM-A217F

Android 11
XIAOMI M2102J2SC
OPPO CPH2067
GOOGLE Pixel 4 XL

Android 10
BLACKSHARK SHARK KLE-A0
HUAWEI ANA-NX9
SAMSUNG SM-A202F

Android 9
XIAOMI MI 8
VIVO V1809A
MOTOROLA moto g(6)

Android 8.1
XIAOMI POCOPHONE F1
HUAWEI COR-AL10
MEIZU M1816

Android 8.0
MOTOROLA moto e5 play
HUAWEI AUM-L33
HUAWEI BLA-L29
